### PR TITLE
Update AzureGPT Config and App READMEs

### DIFF
--- a/app-k8s/README.md
+++ b/app-k8s/README.md
@@ -152,6 +152,7 @@ Before running the benchmarking script, you need to modify the parameters in run
 
 ### `LLM_AGENT_TYPE`:
 - **Description**: Specifies the type of LLM agent to be used in the benchmark. The format typically includes the name and version of the agent, such as `Qwen/Qwen2.5-72B-Instruct`. This determines which LLM model will be evaluated during the benchmarking process.
+- **Possible Values**: `GPT-4o`, `Qwen/Qwen2.5-72B-Instruct`, `ReAct_Agent`
 - **Example**: `Qwen/Qwen2.5-72B-Instruct`
 
 ### `NUM_QUERIES`:
@@ -180,6 +181,7 @@ Before running the benchmarking script, you need to modify the parameters in run
 
 ### `PROMPT_TYPE`:
 - **Description**: Specifies the type of prompt to use when interacting with the LLM. The prompt type affects the nature of the queries sent to the LLM. You can choose between basic and more advanced prompts, depending on your test requirements.
+- **Possible Values**: `base`, `cot`, `few_shot_basic`
 - **Example**: `base` (Use the basic prompt type)
 
 ### `AGENT_TEST`:

--- a/app-malt/README.md
+++ b/app-malt/README.md
@@ -56,11 +56,12 @@ Below is a list of configurable parameters and the relevant details.
 
 ### `--llm_model_type`:
 - **Description**: Specifies the type of LLM agent to be used in the benchmark. The format typically includes the name and version of the agent, such as `Qwen/Qwen2.5-72B-Instruct`. This determines which LLM model will be evaluated during the benchmarking process.
-- **Possible Values**: Replace this with the desired LLM model type.
-- **Example**: `Qwen/Qwen2.5-72B-Instruct`
+- **Possible Values**: `AzureGPT4Agent`, `GoogleGeminiAgent`, `Qwen2.5-72B-Instruct`, `QwenModel_finetuned`, `ReAct_Agent`
+- **Example**: `Qwen2.5-72B-Instruct`
 
 ### `--prompt_type`:
 - **Description**: Specifies the type of prompt to use when interacting with the LLM. The prompt type affects the nature of the queries sent to the LLM. You can choose between basic and more advanced prompts, depending on your test requirements.
+- **Possible Values**: `base`, `cot`, `few_shot_basic`, `few_shot_semantic`
 - **Example**: `base` (Use the basic prompt type)
 
 ### `--complexity_level`:

--- a/app-malt/README.md
+++ b/app-malt/README.md
@@ -1,51 +1,89 @@
-# Capacity planning in datacenter
+# Capacity Planning in Datacenter
+
+This guide outlines steps to evaluate LLM agent performance on data center planning tasks. Agents are placed in a mock datacenter and tasked with making arbitrary, nonbreaking modifications to the topology while obeying operational constraints.
+
+## Python Prerequisites
+
+To set up the Python environment, we use `conda` to create a virtual environment. You can install the required dependencies by running the following commands:
+
+```bash
+conda env create -f environment_ai_gym.yml
+conda activate ai_gym
+```
+
+## Authentication
+To run open source LLMs like `Qwen2.5-72B-Instruct` locally you will need to authenticate to Huggingface with your Huggingface access token like so:
+```bash
+export HUGGINGFACE_TOKEN="your_huggingface_token"
+```
+Information on how to get an acess token can be found on [here](https://huggingface.co/docs/hub/en/security-tokens).
+
+### Azure GPT Usage
+If you want to use Azure GPT on a Azure VM, you will need to create a `GPT-4o` deployment on Azure AI. If you haven't done so already, you can follow the instructions at the Azure GPT [quickstart](https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart?tabs=keyless%2Ctypescript-keyless%2Cpython-new%2Cbash&pivots=programming-language-python). Once you have a working deployment, you can export the following information:
+```bash
+export AZURE_OPENAI_ENDPOINT="https://your-gpt-4o-deployment.openai.azure.com/"
+export AZURE_OPENAI_DEPLOYMENT_NAME="your-gpt-4o-deployment"
+export AZURE_OPENAI_API_VERSION="YYYY-MM-DD" # Optional. Defaults to "2024-10-01".
+export AZURE_OPENAI_API_KEY="API_KEY" # Not needed if Entra ID is used.
+```
+Instead of explicitly specifying an API key, you can authenticate with Entra ID, which is done via `DefaultAzureCredential`. Using the [Azure CLI](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity) with appropriate role assignment or creating a [managed identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-to-configure-managed-identities?pivots=qs-configure-portal-windows-vm) on the host VM (with similar role assignment) are among a few ways to achieve this. For more information on authentication methods/details refer to the Azure docs (see `DefaultAzureCredential`).
+
 ## Run the application
+
+You can either run the application directly from the command line, or you can modify the parameters in `run_app_malt.sh`, our preprovided run script.
+
 Example usage.
-```python
-python main.py --llm_agent_type AzureGPT4Agent --num_queries 3 --complexity_level level1 level2 --output_dir logs/llm_agents --output_file gpt4o.jsonl --dynamic_benchmark_path data/benchmark_malt.jsonl
+```bash
+# Running directly.
+python main.py 
+    --llm_agent_type AzureGPT4Agent \
+    --num_queries 3 \
+    --complexity_level level1 level2 \
+    --output_dir logs/llm_agents \
+    --output_file gpt4o.jsonl \
+    --dynamic_benchmark_path data/benchmark_malt.jsonl
 ```
 
-```python
-python main.py --llm_agent_type Qwen/Qwen2.5-72B-Instruct --num_queries 3 --complexity_level level1 --output_dir logs/llm_agents --output_file qwen.jsonl --dynamic_benchmark_path data/benchmark_malt.jsonl
+```bash
+# Using our run script (with appropriate modifications).
+cd experiments
+bash run_app_malt.sh
 ```
 
-## Code structure
-`dy_query_generation.py` generate the dynamic benchmark datset. Input: number of queries per cataorgory, complexity level; Output: benchmark_data.jsonl
+### Explanation of Command Line Arguments
 
-`solid_step_helper.py` contains all the functions that help dynamically generating ground truth for new queries.
+Below is a list of configurable parameters and the relevant details.
 
-`error_check.py` check if LLM generated answer satisify all the safety constraints.
+### `--llm_model_type`:
+- **Description**: Specifies the type of LLM agent to be used in the benchmark. The format typically includes the name and version of the agent, such as `Qwen/Qwen2.5-72B-Instruct`. This determines which LLM model will be evaluated during the benchmarking process.
+- **Possible Values**: Replace this with the desired LLM model type.
+- **Example**: `Qwen/Qwen2.5-72B-Instruct`
 
-`llm_model.py` includes all the LLM agents and their prompt used.
+### `--prompt_type`:
+- **Description**: Specifies the type of prompt to use when interacting with the LLM. The prompt type affects the nature of the queries sent to the LLM. You can choose between basic and more advanced prompts, depending on your test requirements.
+- **Example**: `base` (Use the basic prompt type)
 
-`malt_env.py` is the application simulator. It takes the LLM generated answer, run it in the enviroment and return the evaluated results.
+### `--complexity_level`:
+- **Description**: A space separated list that determines what level queries will be evaluated with each level having one or more different types of queries. For example, `level1` has 4 different types of queries. Possible values include: `level1`, `level2`, and `level3`.
+- **Accepted Values**: Any combination of `level1`, `level2`, and `level3`
+- **Example**: `level1 level3` (Only test with level 1 and level 3 queries)
 
-`main.py` is the end-to-end controller. It first generate a new set of benchmark, second run the LLM agent, third analyze the results.
+### `--num_queries`:
+- **Description**: Defines the number of queries to generate during the benchmarking process. This determines how many individual queries for each error type will be tested.
+- **Example**: `10` (Test with 10 queries per type, so 40 queries total with `level1`)
 
-## LLM usage
-### Azure GPT
-Obtain GPT resources and endpoints
-If you use Azure GPT on a Azure VM, need to use the following
-```python
-from azure.identity import AzureCliCredential
-# Get the Azure Credential
-credential = AzureCliCredential()
-```
-Otherwise, use the following
-```python
-from azure.identity import DefaultAzureCredential
-# Get the Azure Credential
-credential = DefaultAzureCredential()
-```
-And please update the below with your own endpoint information
-```python
-#Set the API type to `azure_ad`
-os.environ["OPENAI_API_TYPE"] = "azure_ad"
-# Set the API_KEY to the token from the Azure credential
-os.environ["OPENAI_API_KEY"] = credential.get_token("please_update").token
-# Set the ENDPOINT
-os.environ["AZURE_OPENAI_ENDPOINT"] = "please_update"
-```
+### `--output_dir`:
+- **Description**: The output directory where output figures, logs, etc will be stored. This path should point to the location on your machine where the benchmark results will be saved. Ensure that the specified directory exists and is accessible.
+- **Example**: `/home/ubuntu/NetPress_benchmark/app-malt/data/results`
 
+### `--output_file`:
+- **Description**: The output file name (JSONL) containing the LLM response, and the correctness/safety information versus the ground truth. The output file will be saved under `--output_dir`.
+- **Example**: `malt_100q_level1_eval.jsonl` (so output would be saved to `"${OUTPUT_DIR}/malt_100q_level1_eval.jsonl"`)
 
+### `--regenerate_query`:
+- **Description**:If specified, generates a new configuration based on the `--complexity_level` and `--num_queries` specified. Saves to `--dynamic_benchmark_path`.
+
+### `--dynamic_benchmark_path`:
+- **Description**: The path where the above benchmark containing the generated queries will be saved (JSONL). If `--regenerate_query` is not specified, then this parameter indicates where the existing benchmark file can be found.
+- **Example**: `/home/ubuntu/NetPress_benchmark/app-malt/data/malt_bench_100q_level1.jsonl`
 

--- a/app-malt/llm_model.py
+++ b/app-malt/llm_model.py
@@ -35,6 +35,7 @@ login(token=huggingface_token)
 # For Azure OpenAI GPT4
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from langchain.chat_models import AzureChatOpenAI
+from langchain.chat_models import ChatGoogleGenerativeAI
 import getpass
 
 mp.set_start_method('spawn', force=True)

--- a/app-malt/llm_model.py
+++ b/app-malt/llm_model.py
@@ -35,16 +35,7 @@ login(token=huggingface_token)
 # For Azure OpenAI GPT4
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from langchain.chat_models import AzureChatOpenAI
-credential = DefaultAzureCredential()
-token_provider = get_bearer_token_provider(
-        DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
-    )
-#Set the API type to `azure_ad`
-os.environ["OPENAI_API_TYPE"] = "azure_ad"
-# Set the API_KEY to the token from the Azure credential
-os.environ["OPENAI_API_KEY"] = credential.get_token("please_update").token
-# Set the ENDPOINT
-os.environ["AZURE_OPENAI_ENDPOINT"] = "please_update"
+import getpass
 
 mp.set_start_method('spawn', force=True)
 
@@ -124,10 +115,10 @@ class GoogleGeminiAgent:
 
 class AzureGPT4Agent:
     def __init__(self, prompt_type="base"):
+        self.configure_environment_variables()
         self.llm = AzureChatOpenAI(
-            openai_api_version="2024-12-01-preview",
-            deployment_name='ztn-sweden-gpt-4o',
-            model_name='ztn-sweden-gpt-4o',
+            openai_api_version=os.environ["AZURE_OPENAI_API_VERSION"],
+            deployment_name=os.environ["AZURE_OPENAI_DEPLOYMENT_NAME"],
             temperature=0.0,
             max_tokens=4000,
         )
@@ -141,6 +132,30 @@ class AzureGPT4Agent:
             self.prompt_agent = FewShot_Semantic_PromptAgent()
         else:
             self.prompt_agent = BasePromptAgent()
+
+    @staticmethod
+    def configure_environment_variables():
+        """Authenticates with Azure OpenAI and sets environment variables (prompting the user when necessary) if not already set."""
+        # TODO: Is there a way to get the latest (stable) version programatically?
+        DEFAULT_AZURE_OPENAI_API_VERSION = "2024-10-01"
+
+        # Set the API_KEY to the token from the Azure credential
+        if "AZURE_OPENAI_API_KEY" not in os.environ:
+            try:
+                credential = DefaultAzureCredential()
+                os.environ["AZURE_OPENAI_API_KEY"] = credential.get_token("https://cognitiveservices.azure.com/.default").token
+            except Exception as e:
+                print("Error retrieving Azure OpenAI API key (authenticating with Entra ID failed):", e)
+                os.environ["AZURE_OPENAI_API_KEY"] = getpass.getpass("Please enter your Azure OpenAI API key: ")
+        # Get the endpoint of deployed AzureGPT model.
+        if "AZURE_OPENAI_ENDPOINT" not in os.environ:
+            os.environ["AZURE_OPENAI_ENDPOINT"] = getpass.getpass("Please enter your Azure OpenAI endpoint: ")
+        # Get the deployment name
+        if "AZURE_OPENAI_DEPLOYMENT_NAME" not in os.environ:
+            os.environ["AZURE_OPENAI_DEPLOYMENT_NAME"] = getpass.getpass("Please enter your Azure OpenAI deployment name: ")
+        # Get the OpenAI API version
+        if "AZURE_OPENAI_API_VERSION" not in os.environ:
+            os.environ["AZURE_OPENAI_API_VERSION"] = DEFAULT_AZURE_OPENAI_API_VERSION
 
     def call_agent(self, query):
         print("Calling GPT-4o with prompt type:", self.prompt_type)
@@ -354,10 +369,10 @@ from langchain_community.tools import DuckDuckGoSearchRun
 from langchain_experimental.tools.python.tool import PythonAstREPLTool
 class ReAct_Agent:
     def __init__(self, prompt_type="react"):
+        AzureGPT4Agent.configure_environment_variables()
         self.llm = AzureChatOpenAI(
-            openai_api_version="2024-12-01-preview",
-            deployment_name='ztn-sweden-gpt-4o',
-            model_name='ztn-sweden-gpt-4o',
+            openai_api_version=os.environ["AZURE_OPENAI_API_VERSION"],
+            deployment_name=os.environ["AZURE_OPENAI_DEPLOYMENT_NAME"],
             temperature=0.0,
             max_tokens=4000,
         )

--- a/app-malt/main.py
+++ b/app-malt/main.py
@@ -14,7 +14,7 @@ import argparse
 from scipy import stats
 import math
 
-# define a configuration for the benchmark
+# Define a configuration for the benchmark
 def parse_args():
     parser = argparse.ArgumentParser(description="Benchmark Configuration")
     parser.add_argument('--llm_model_type', type=str, default='AzureGPT4Agent', help='Choose the LLM agent', choices=['AzureGPT4Agent', 
@@ -34,7 +34,7 @@ def parse_args():
     parser.add_argument('--end_index', type=int, default=None, help='End index of the queries to run (zero indexed).')
     return parser.parse_args()
 
-# anexample of how to use main.py with input args
+# An example of how to use main.py with input args
 # Example usage:
 # python main.py --llm_agent_type AzureGPT4Agent --num_queries 2 --complexity_level level1 --output_dir logs/llm_agents --output_file gpt4o.jsonl --dynamic_benchmark_path data/benchmark_malt.jsonl
 

--- a/app-route/README.md
+++ b/app-route/README.md
@@ -53,7 +53,7 @@ Before running the benchmarking script, you need to modify the parameters in `ru
 
 ### `MODEL`:
 - **Description**: Specifies the type of LLM agent to be used in the benchmark. The format typically includes the name and version of the agent, such as `Qwen/Qwen2.5-72B-Instruct`. This determines which LLM model will be evaluated during the benchmarking process.
-- **How to modify**: Replace this with the desired LLM model type.
+- **Possible Values**: `GPT-Agent`, `Qwen/Qwen2.5-72B-Instruct`, `ReAct_Agent`, `YourModel`
 - **Example**: `Qwen/Qwen2.5-72B-Instruct`
 
 ### `NUM_QUERIES`:
@@ -78,6 +78,7 @@ Before running the benchmarking script, you need to modify the parameters in `ru
 
 ### `PROMPT_TYPE`:
 - **Description**: Specifies the type of prompt to use when interacting with the LLM. The prompt type affects the nature of the queries sent to the LLM. You can choose between basic and more advanced prompts, depending on your test requirements.
+- **Possible Values**: `base`, `cot`, `few_shot_basic`
 - **Example**: `base` (Use the basic prompt type)
 
 ### `NUM_GPUS`:
@@ -93,7 +94,7 @@ After modifying the parameters, you can execute the benchmarking process by runn
 ```bash
 bash run_app_route.sh
 ```
-# Testing Your Own Model
+## Testing Your Own Model
 
 To test your own model, follow these steps:
 
@@ -106,4 +107,4 @@ To test your own model, follow these steps:
    - In the `_load_model` method, update the correct way to load your own model.
    - In the `predict` method, modify the code to generate results using your LLM based on the provided prompt.
 
-Once these modifications are complete, your model will be ready to be integrated into the benchmark environment. You can then proceed with testing by following the instructions in the `Running Benchmark Tests` section.
+Once these modifications are complete, your model will be ready to be integrated into the benchmark environment. You can then proceed with testing by following the instructions in the **Running Benchmark Tests** section.

--- a/app-route/README.md
+++ b/app-route/README.md
@@ -1,5 +1,6 @@
-# README
+# Routing Application Setup
 
+This app serves to evaluate the capabilities of different LLM agents on dynamically generated routing configuration tasks in a simulated network. The following guide outlines necessary configuration steps to get started.
 
 ## Python Prerequisites
 
@@ -10,7 +11,7 @@ conda env create -f environment_mininet.yml
 conda activate mininet
 ```
 
-### Install Mininet Emulator Environment
+## Install Mininet Emulator Environment
 To install the Mininet emulator, run the following command (we tested on Ubuntu 22.04):
 
 ```
@@ -19,18 +20,34 @@ chmod +x install_mininet.sh
 ```
 
 If you see `Enjoy Mininet`, you install mininet environment successfully!
-### Set the environment variable:
-You need to set environment variable so that you can access open source LLM. You can do it by using the following command:
-```
+
+## Authentication
+To run open source LLMs like `Qwen2.5-72B-Instruct` locally you will need to authenticate to Huggingface with your Huggingface access token like so:
+```bash
 export HUGGINGFACE_TOKEN="your_huggingface_token"
 ```
+Information on how to get an acess token can be found on [here](https://huggingface.co/docs/hub/en/security-tokens).
+
+### Azure GPT Usage
+If you want to use Azure GPT on a Azure VM, you will need to create a `GPT-4o` deployment on Azure AI. If you haven't done so already, you can follow the instructions at the Azure GPT [quickstart](https://learn.microsoft.com/en-us/azure/ai-services/openai/chatgpt-quickstart?tabs=keyless%2Ctypescript-keyless%2Cpython-new%2Cbash&pivots=programming-language-python). Once you have a working deployment, you can export the following information:
+```bash
+export AZURE_OPENAI_ENDPOINT="https://your-gpt-4o-deployment.openai.azure.com/"
+export AZURE_OPENAI_DEPLOYMENT_NAME="your-gpt-4o-deployment"
+export AZURE_OPENAI_API_VERSION="YYYY-MM-DD" # Optional. Defaults to "2024-10-01".
+export AZURE_OPENAI_API_KEY="API_KEY" # Not needed if Entra ID is used.
+```
+Instead of explicitly specifying an API key, you can authenticate with Entra ID, which is done via `DefaultAzureCredential`. Using the [Azure CLI](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/managed-identity) with appropriate role assignment or creating a [managed identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-to-configure-managed-identities?pivots=qs-configure-portal-windows-vm) on the host VM (with similar role assignment) are among a few ways to achieve this. For more information on authentication methods/details refer to the Azure docs (see `DefaultAzureCredential`).
+
 ## Running Benchmark Tests
+
+The quickest way to start is to use our already provided experiment script.
+
 ### 1. Navigate to experiments
 To run the benchmark tests, you can use our `run_app_route.sh` in `experiments`:
 ```
 cd experiments
 ```
-### 2. Modify Parameters in `run_app_k8s.sh`
+### 2. Modify Parameters in `run_app_route.sh`
 
 Before running the benchmarking script, you need to modify the parameters in `run_app_route.sh` to suit your setup.  Below is a list of configurable parameters and their explanations.
 
@@ -41,11 +58,11 @@ Before running the benchmarking script, you need to modify the parameters in `ru
 
 ### `NUM_QUERIES`:
 - **Description**: Defines the number of queries to generate during the benchmarking process. This determines how many individual queries for each error type will be tested.
-- **Example**: `10` (Test with one query)
+- **Example**: `10` (Test with 10 queries per type)
 
 ### `ROOT_DIR`:
 - **Description**: The root directory where output logs and results will be stored. This path should point to the location on your machine where the benchmark results will be saved. Ensure that the specified directory exists and is accessible.
-- **Example**: `/home/ubuntu/nemo_benchmark/app-route`
+- **Example**: `/home/ubuntu/NetPress_benchmark/app-route/results`
 
 ### `MAX_ITERATION`:
 - **Description**: The maximum number of iterations to run for each query. This helps control the number of times the agent will execute the query in each benchmark run. 
@@ -55,9 +72,21 @@ Before running the benchmarking script, you need to modify the parameters in `ru
 - **Description**: This parameter controls whether a new configuration should be generated for each benchmark. Set it to `1` to generate a new configuration, or `0` to skip this step and use the existing configuration.
 - **Example**: `1` (Generate new configuration)
 
+### `BENCHMARK_PATH`:
+- **Description**: The path where the above config (benchmark) containing the generated queries will be saved (JSON). If `STATIC_GEN=0`, then this parameter indicates where the existing config file can be found.
+- **Example**: `/home/ubuntu/NetPress_benchmark/app-route/results/error_config.json`
+
 ### `PROMPT_TYPE`:
 - **Description**: Specifies the type of prompt to use when interacting with the LLM. The prompt type affects the nature of the queries sent to the LLM. You can choose between basic and more advanced prompts, depending on your test requirements.
 - **Example**: `base` (Use the basic prompt type)
+
+### `NUM_GPUS`:
+- **Description**: The number of GPUs to use with VLLM for tensor parallelism. This parameter only applies to locally run models like `Qwen2.5-72B-Instruct`, and should not used with `AGENT_TEST=1`. Note that the `NUM_GPUS` should evenly divide the number of attention heads of the model to be run. By default, only the first GPU is used, with the rest spilling over to RAM/disk.
+- **Example**: `4`
+
+### `PARALLEL`:
+- **Description**: If set to 1 (0 otherwise), runs evaluation on multiple prompt types in parallel. Should not be used with `NUM_GPUS` values greater than 1 when running local models. If you want to run parallel evaluation with multiple GPUs locally you are better off setting `CUDA_VISIBLE_DEVICES` and running each experiment manually to distribute GPUs properly. 
+- **Example**: `0`
 
 ### 3. Run the Benchmark
 After modifying the parameters, you can execute the benchmarking process by running the script with the following command:
@@ -78,29 +107,3 @@ To test your own model, follow these steps:
    - In the `predict` method, modify the code to generate results using your LLM based on the provided prompt.
 
 Once these modifications are complete, your model will be ready to be integrated into the benchmark environment. You can then proceed with testing by following the instructions in the `Running Benchmark Tests` section.
-
-
-### Note: Azure GPT usage
-Obtain GPT resources and endpoints
-If you use Azure GPT on a Azure VM, need to use the following
-```python
-from azure.identity import AzureCliCredential
-# Get the Azure Credential
-credential = AzureCliCredential()
-```
-Otherwise, use the following
-```python
-from azure.identity import DefaultAzureCredential
-# Get the Azure Credential
-credential = DefaultAzureCredential()
-```
-And please update the below with your own endpoint information
-```python
-#Set the API type to `azure_ad`
-os.environ["OPENAI_API_TYPE"] = "azure_ad"
-# Set the API_KEY to the token from the Azure credential
-os.environ["OPENAI_API_KEY"] = credential.get_token("please_update").token
-# Set the ENDPOINT
-os.environ["AZURE_OPENAI_ENDPOINT"] = "please_update"
-
-```

--- a/app-route/main.py
+++ b/app-route/main.py
@@ -17,7 +17,7 @@ def parse_args():
     parser.add_argument('--num_gpus', type=int, default=1, help='The number of GPUs to use for tensor parallelism (VLLM).')
     parser.add_argument('--benchmark_path', type=str, default='error_config.json', help='Where to save the generated benchmark relative to root_dir (or where to look for it).')
     parser.add_argument('--static_benchmark_generation', type=int, default=0, choices=[0, 1], help='If set to 1, generate static benchmark')
-    parser.add_argument('--prompt_type', type=str, default="base", help='Path to the error configuration file')
+    parser.add_argument('--prompt_type', type=str, default="base", choices=["base", "cot", "few_shot_basic"], help='Choose the prompt type')
     parser.add_argument('--parallel', type=int, default=1, choices=[0, 1], help='If set to 1, run in parallel')
     return parser.parse_args()
 

--- a/experiments/run_app_k8s.sh
+++ b/experiments/run_app_k8s.sh
@@ -22,6 +22,12 @@ LOG_FILE="${ROOT_DIR}/${SAFE_LLM_AGENT_TYPE}_${PROMPT_TYPE}.log"
 
 export HUGGINGFACE_TOKEN="[YOUR_TOKEN_HERE]"  # Set your Hugging Face token here
 
+# Azure OpenAI configuration
+export AZURE_OPENAI_ENDPOINT="https://your-gpt-4o-deployment.openai.azure.com/"
+export AZURE_OPENAI_DEPLOYMENT_NAME="your-gpt-4o-deployment"
+export AZURE_OPENAI_API_VERSION="YYYY-MM-DD" # Optional. Defaults to "2024-10-01".
+export AZURE_OPENAI_API_KEY="API_KEY" # Not needed if Entra ID is used.
+
 # Create the log file if it does not exist
 touch "$LOG_FILE"
 

--- a/experiments/run_app_malt.sh
+++ b/experiments/run_app_malt.sh
@@ -3,13 +3,19 @@ cd ..
 cd app-malt
 
 # Define common parameters
-NUM_QUERIES=500
-BENCHMARK_PATH="data/sampled_500_benchmark_malt.jsonl"
+NUM_QUERIES=1
+BENCHMARK_PATH="data/sampled_1_benchmark_malt.jsonl"
 PROMPT_TYPE="few_shot_semantic"  # Define prompt_type
 # PROMPT_TYPE="few_shot_basic"  # Define prompt_type
 # PROMPT_TYPE="zero_shot_cot"  # Define prompt_type
 
 export HUGGINGFACE_TOKEN="[YOUR_TOKEN_HERE]"  # Set your Hugging Face token here
+
+# Azure OpenAI configuration
+export AZURE_OPENAI_ENDPOINT="https://your-gpt-4o-deployment.openai.azure.com/"
+export AZURE_OPENAI_DEPLOYMENT_NAME="your-gpt-4o-deployment"
+export AZURE_OPENAI_API_VERSION="YYYY-MM-DD" # Optional. Defaults to "2024-10-01".
+export AZURE_OPENAI_API_KEY="API_KEY" # Not needed if Entra ID is used.
 
 # Function to run experiment for a model
 run_experiment() {

--- a/experiments/run_app_route.sh
+++ b/experiments/run_app_route.sh
@@ -21,6 +21,12 @@ LOG_FILE="${ROOT_DIR}/experiment_$(date +'%Y-%m-%d_%H-%M-%S').log"
 
 export HUGGINGFACE_TOKEN="[YOUR_TOKEN_HERE]"  # Set your Hugging Face token here
 
+# Azure OpenAI configuration
+export AZURE_OPENAI_ENDPOINT="https://your-gpt-4o-deployment.openai.azure.com/"
+export AZURE_OPENAI_DEPLOYMENT_NAME="your-gpt-4o-deployment"
+export AZURE_OPENAI_API_VERSION="YYYY-MM-DD" # Optional. Defaults to "2024-10-01".
+export AZURE_OPENAI_API_KEY="API_KEY" # Not needed if Entra ID is used.
+
 # Function to clean up existing controller processes
 cleanup_controllers() {
     echo "Cleaning up existing controller processes..." | tee -a "$LOG_FILE"


### PR DESCRIPTION
# Overview

Make configuration of AzureGPT based agents lean more towards environment variables for all apps. Updated app specific `README.md` files to reflect this change and to improve clarity in general. 

## Azure GPT Changes

Instead of having to modify the source code, users can now just export the corresponding environment variables and/or authenticate with Microsoft Entra ID to enable AzureGPT like so:
```bash
export AZURE_OPENAI_ENDPOINT="https://your-gpt-4o-deployment.openai.azure.com/"
export AZURE_OPENAI_DEPLOYMENT_NAME="your-gpt-4o-deployment"
export AZURE_OPENAI_API_VERSION="YYYY-MM-DD" # Optional. Defaults to "2024-10-01".
export AZURE_OPENAI_API_KEY="API_KEY" # Not needed if Entra ID is used.
```
Furthermore, the code should now only ask for/require these credentials if you actually select `AzureGPTAgent`.

## README

Links to the READMEs for convenience: [app-k8s](https://github.com/lesleychou/NetPress_benchmark/tree/update_azure_gpt_config/app-k8s), [app-route](https://github.com/lesleychou/NetPress_benchmark/tree/update_azure_gpt_config/app-route), [app-malt](https://github.com/lesleychou/NetPress_benchmark/tree/update_azure_gpt_config/app-malt)

- Expanded explanation of command line arguments/parameters and permissible values.
- Information on authentication (Huggingface and AzureGPT).
- Minor reformatting/rearrangements.

## Other

- Include missing import for LLM in `GeminiAgent` (`app-malt`).
- Fix some typos in arg parser/comments of main scripts.
- Update experiment scripts to reflect AzureGPT changes.
