### PR TITLE
app-malt: Num_gpus option

### DIFF
--- a/app-malt/README.md
+++ b/app-malt/README.md
@@ -88,3 +88,7 @@ Below is a list of configurable parameters and the relevant details.
 - **Description**: The path where the above benchmark containing the generated queries will be saved (JSONL). If `--regenerate_query` is not specified, then this parameter indicates where the existing benchmark file can be found.
 - **Example**: `/home/ubuntu/NetPress_benchmark/app-malt/data/malt_bench_100q_level1.jsonl`
 
+### `--num_gpus`:
+- **Description**: The number of GPUs to use with VLLM for tensor parallelism. This parameter only applies to locally run models like `Qwen2.5-72B-Instruct`. Note that the `--num_gpus` should evenly divide the number of attention heads of the model to be run. By default, only the first GPU is used, with the rest spilling over to RAM/disk.
+- **Example**: `4`
+

--- a/app-malt/llm_model.py
+++ b/app-malt/llm_model.py
@@ -181,13 +181,16 @@ class AzureGPT4Agent:
         return code
    
 class QwenModel:
-    def __init__(self, prompt_type="base"):
+    def __init__(self, prompt_type="base", num_gpus=1):
         self.model_name = "Qwen/Qwen2.5-72B-Instruct-GPTQ-Int4"
+        os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.llm = LLM(
             model=self.model_name,
             device=self.device,
-            quantization="gptq"
+            quantization="gptq",
+            gpu_memory_utilization=0.95,
+            tensor_parallel_size=num_gpus
         )
         self.sampling_params = SamplingParams(
             temperature=0.0,

--- a/app-malt/main.py
+++ b/app-malt/main.py
@@ -32,6 +32,7 @@ def parse_args():
     parser.add_argument('--regenerate_query', action='store_true', help='Whether to regenerate benchmark queries or load existing ones')
     parser.add_argument('--start_index', type=int, default=0, help='Start index of the queries to run (zero indexed).')
     parser.add_argument('--end_index', type=int, default=None, help='End index of the queries to run (zero indexed).')
+    parser.add_argument('--num_gpus', type=int, default=1, help='Number of GPUs to use for tensor parallelism (VLLM). Only applies to locally run models.')
     return parser.parse_args()
 
 # anexample of how to use main.py with input args
@@ -51,7 +52,8 @@ def main(args):
         'dynamic_benchmark_path': args.dynamic_benchmark_path,
         'regenerate_query': args.regenerate_query,
         'start_index': args.start_index,
-        'end_index': args.end_index
+        'end_index': args.end_index,
+        'num_gpus': args.num_gpus
     }
 
     # create the output directory if it does not exist
@@ -83,7 +85,7 @@ def main(args):
 
     # Load the evaluator
     evaluator = BenchmarkEvaluator(graph_data=query_generator.malt_real_graph, llm_model_type=benchmark_config['llm_model_type'], 
-                                   prompt_type=benchmark_config['prompt_type'], model_path=benchmark_config['model_path'])
+                                   prompt_type=benchmark_config['prompt_type'], model_path=benchmark_config['model_path'], num_gpus=benchmark_config['num_gpus'])
 
     # the format is {"messages": [{"question": "XXX."}, {"answer": "YYY"}]}
     benchmark_data = []

--- a/app-malt/malt_env.py
+++ b/app-malt/malt_env.py
@@ -28,7 +28,7 @@ OUTPUT_JSONL_FILE = 'gpt4.jsonl'
 
 
 class BenchmarkEvaluator:
-    def __init__(self, graph_data, llm_model_type, prompt_type, model_path=None):
+    def __init__(self, graph_data, llm_model_type, prompt_type, model_path=None, num_gpus=1):
         self.graph_data = graph_data
         # Call the output code from LLM agents file
         if llm_model_type == "AzureGPT4Agent":
@@ -36,7 +36,7 @@ class BenchmarkEvaluator:
         elif llm_model_type == "GoogleGeminiAgent":
             self.llm_agent = GoogleGeminiAgent(prompt_type)
         elif llm_model_type == "Qwen2.5-72B-Instruct":
-            self.llm_agent = QwenModel(prompt_type)
+            self.llm_agent = QwenModel(prompt_type, num_gpus=num_gpus)
         elif llm_model_type == "QwenModel_finetuned":
             self.llm_agent = QwenModel_finetuned(prompt_type, model_path=model_path)
         elif llm_model_type == "ReAct_Agent":

--- a/app-route/llm_model.py
+++ b/app-route/llm_model.py
@@ -302,7 +302,7 @@ class Qwen_vllm_Model:
 
     def _load_model(self):
         """Load the Qwen model using vllm with GPTQ 4-bit quantization."""
-
+        os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
         self.llm = LLM(
             model=self.model_name,
             device=self.device,

--- a/experiments/run_app_malt.sh
+++ b/experiments/run_app_malt.sh
@@ -6,6 +6,7 @@ cd app-malt
 NUM_QUERIES=500
 BENCHMARK_PATH="data/sampled_500_benchmark_malt.jsonl"
 PROMPT_TYPE="few_shot_semantic"  # Define prompt_type
+NUM_GPUS=4 # Number of GPUs to use for tensor parallelism (only applicable to Qwen2.5-72B-Instruct).
 # PROMPT_TYPE="few_shot_basic"  # Define prompt_type
 # PROMPT_TYPE="zero_shot_cot"  # Define prompt_type
 
@@ -34,6 +35,7 @@ run_experiment() {
         --output_dir "$agent_output_dir" \
         --output_file "$output_file" \
         --dynamic_benchmark_path "$BENCHMARK_PATH" \
+        --num_gpus "$NUM_GPUS" \
         --regenerate_query
     }
 


### PR DESCRIPTION
# Overview
Adding option to specify GPUs to use for running local models to be consistent with the other apps.
- Add `--num_gpus` command line option to `app-malt` for `Qwen2.5-72B-Instruct` (VLLM)
- Update app `README.md` and experiment script to include `--num_gpus` info/option